### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,7 +5,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jasonwalsh/punk/punk
           password: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore